### PR TITLE
Expose default values as a "Default" field on Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ func main() {
             Names:       []string{"bootloader"},
             Description: "Use the specified bootloader (grub, grub2, or lilo)",
             Decoder:     writ.NewOptionDecoder(&config.bootloader),
+            Default:     writ.StringDefault("grub2"),
             Placeholder: "NAME",
         })
         platform := cmd.GroupOptions("bootloader")

--- a/command_test.go
+++ b/command_test.go
@@ -348,16 +348,16 @@ var defaultFieldTests = []defaultFieldTest{
 	{Args: []string{""}, Valid: true, Field: "EnvDefault", Value: 0},
 	{Args: []string{""}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "2", Field: "EnvDefault", Value: 2},
 	{Args: []string{"-e", "4"}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "2", Field: "EnvDefault", Value: 4},
+	{Args: []string{"-e", "4"}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "foo", Field: "EnvDefault", Value: 4},
 	{Args: []string{""}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "foo"},
-	{Args: []string{"-e", "4"}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-e", "foo"}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "2"},
 
 	// Field with both a default value and an environment default
 	{Args: []string{""}, Valid: true, Field: "StackedDefault", Value: 84},
 	{Args: []string{""}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "2", Field: "StackedDefault", Value: 2},
 	{Args: []string{"-s", "4"}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "2", Field: "StackedDefault", Value: 4},
+	{Args: []string{"-s", "4"}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "foo", Field: "StackedDefault", Value: 4},
 	{Args: []string{""}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
-	{Args: []string{"-s", "4"}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-s", "foo"}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-s", "foo"}, Valid: false},
 }

--- a/command_test.go
+++ b/command_test.go
@@ -347,17 +347,17 @@ var defaultFieldTests = []defaultFieldTest{
 	// Field with an environment default
 	{Args: []string{""}, Valid: true, Field: "EnvDefault", Value: 0},
 	{Args: []string{""}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "2", Field: "EnvDefault", Value: 2},
-	{Args: []string{""}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "foo", Field: "EnvDefault", Value: 0},
 	{Args: []string{"-e", "4"}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "2", Field: "EnvDefault", Value: 4},
-	{Args: []string{"-e", "4"}, Valid: true, EnvKey: "ENV_DEFAULT", EnvValue: "foo", Field: "EnvDefault", Value: 4},
+	{Args: []string{""}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "foo"},
+	{Args: []string{"-e", "4"}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-e", "foo"}, Valid: false, EnvKey: "ENV_DEFAULT", EnvValue: "2"},
 
 	// Field with both a default value and an environment default
 	{Args: []string{""}, Valid: true, Field: "StackedDefault", Value: 84},
 	{Args: []string{""}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "2", Field: "StackedDefault", Value: 2},
-	{Args: []string{""}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "foo", Field: "StackedDefault", Value: 84},
 	{Args: []string{"-s", "4"}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "2", Field: "StackedDefault", Value: 4},
-	{Args: []string{"-s", "4"}, Valid: true, EnvKey: "STACKED_DEFAULT", EnvValue: "foo", Field: "StackedDefault", Value: 4},
+	{Args: []string{""}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
+	{Args: []string{"-s", "4"}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-s", "foo"}, Valid: false, EnvKey: "STACKED_DEFAULT", EnvValue: "foo"},
 	{Args: []string{"-s", "foo"}, Valid: false},
 }
@@ -405,21 +405,11 @@ func TestBogusDefaultField(t *testing.T) {
 		BogusDefault int `option:"b" description:"An int field with a bogus default" default:"bogus"`
 	}{}
 
-	defer func() {
-		r := recover()
-		if r != nil {
-			switch r.(type) {
-			case commandError, optionError:
-				// Intentional No-op
-			default:
-				panic(r)
-			}
-		}
-	}()
-
 	cmd := New("test", spec)
-	cmd.Decode([]string{})
-	t.Errorf("Expected decoding to panic on bogus default value, but this didn't happen.")
+	_, _, err := cmd.Decode([]string{})
+	if err == nil {
+		t.Errorf("Expected decoding error on bogus default value, but this didn't happen.")
+	}
 }
 
 /*

--- a/doc.go
+++ b/doc.go
@@ -91,9 +91,7 @@ The New() function recognizes the following combinations of field tags:
 		- description: the description to display for help output
 
 If both "default" and "env" are specified for an option field, the environment
-variable is consulted first.  If the environment variable is present and
-decodes without error, that value is used.  Otherwise, the value for the
-"default" tag is used.  Values specified via parsed arguments take precedence
-over both types of defaults.
+variable is consulted first.  Values specified via parsed arguments take
+precedence over both types of defaults.
 */
 package writ

--- a/example_explicit_test.go
+++ b/example_explicit_test.go
@@ -55,6 +55,7 @@ func Example_explicit() {
 			Names:       []string{"bootloader"},
 			Description: "Use the specified bootloader (grub, grub2, or lilo)",
 			Decoder:     writ.NewOptionDecoder(&config.bootloader),
+			Default:     writ.StringDefault("grub2"),
 			Placeholder: "NAME",
 		})
 		platform := cmd.GroupOptions("bootloader")

--- a/option.go
+++ b/option.go
@@ -341,13 +341,16 @@ type flagAccumulator struct {
 	value *int
 }
 
-// Defaulter returns a default value for an Option
+// Defaulter returns a default value for an Option.
 type Defaulter interface {
 	Default() string
 }
 
+// StringDefault returns its value when Default() is called.  This makes it easy to
+// pass string values as defaults for the Option.Default field.
 type StringDefault string
 
+// Default returns the string value of d
 func (d StringDefault) Default() string {
 	return string(d)
 }
@@ -370,6 +373,7 @@ func (d envDefaulter) Default() string {
 // and returns the first non-empty value, or "" if all values are empty.
 type ChainedDefault []Defaulter
 
+// Default returns the first non-empty value for the elements in d, or "".
 func (d ChainedDefault) Default() string {
 	for _, defaulter := range d {
 		value := defaulter.Default()

--- a/option.go
+++ b/option.go
@@ -370,8 +370,8 @@ func (d envDefaulter) Default() string {
 // and returns the first non-empty value, or "" if all values are empty.
 type ChainedDefault []Defaulter
 
-func (dc ChainedDefault) Default() string {
-	for _, defaulter := range dc {
+func (d ChainedDefault) Default() string {
+	for _, defaulter := range d {
 		value := defaulter.Default()
 		if value != "" {
 			return value

--- a/option.go
+++ b/option.go
@@ -62,11 +62,11 @@ type Option struct {
 	Decoder OptionDecoder
 
 	// Optional
-	Default     Defaulter // If set, Decoder.Decode() is called with Default.Default() prior to decoding args
-	Flag        bool            // If set, the Option takes no arguments
-	Plural      bool            // If set, the Option may be specified multiple times
-	Description string          // Options without descriptions are hidden
-	Placeholder string          // Displayed next to option in help output (e.g. FILE)
+	Default     Defaulter // The Default value is used when no explicit value is provided
+	Flag        bool      // If set, the Option takes no arguments
+	Plural      bool      // If set, the Option may be specified multiple times
+	Description string    // Options without descriptions are hidden
+	Placeholder string    // Displayed next to option in help output (e.g. FILE)
 }
 
 // ShortNames returns a filtered slice of the names that are exactly one rune in length.

--- a/option.go
+++ b/option.go
@@ -62,7 +62,7 @@ type Option struct {
 	Decoder OptionDecoder
 
 	// Optional
-	Default     OptionDefaulter // If set, Decoder.Decode() is called with Default.Default() prior to decoding args
+	Default     Defaulter // If set, Decoder.Decode() is called with Default.Default() prior to decoding args
 	Flag        bool            // If set, the Option takes no arguments
 	Plural      bool            // If set, the Option may be specified multiple times
 	Description string          // Options without descriptions are hidden
@@ -341,8 +341,8 @@ type flagAccumulator struct {
 	value *int
 }
 
-// OptionDefaulter returns a default value for an Option
-type OptionDefaulter interface {
+// Defaulter returns a default value for an Option
+type Defaulter interface {
 	Default() string
 }
 
@@ -352,9 +352,9 @@ func (d StringDefault) Default() string {
 	return string(d)
 }
 
-// NewEnvDefault builds an OptionDefaulter that returns the value of the
+// NewEnvDefault builds a Defaulter that returns the value of the
 // environment variable named by key when it's Default() method is called.
-func NewEnvDefault(key string) OptionDefaulter {
+func NewEnvDefault(key string) Defaulter {
 	return envDefaulter{key}
 }
 
@@ -368,7 +368,7 @@ func (d envDefaulter) Default() string {
 
 // ChainedDefault checks the Default() value of each element in it's slice
 // and returns the first non-empty value, or "" if all values are empty.
-type ChainedDefault []OptionDefaulter
+type ChainedDefault []Defaulter
 
 func (dc ChainedDefault) Default() string {
 	for _, defaulter := range dc {


### PR DESCRIPTION
@elithrar provided some great feedback on the default value handling.  After some thought, I've put together a PR that decouples the `OptionDefaulter` and `OptionDecoder` interfaces.  With this change, Options would have a separate `Default` field.  As a result, string defaults can be assigned via `opt.Default = writ.StringDefault("value")`, and a `ChainedDefault` can be used to chain together defaults from a `[]Defaulter` slice, returning the first non-empty default.  This is how environment defaults are stacked with regular defaults with this PR.

If I merge this, I'll target the merge for the v1.0 release.  I think I'll probably collect breaking changes and merge them to a separate 1.0-wip branch.
